### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
     "data operations"
   ],
   "description": "Prepare training data for SmartTool",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/create_trainset_for_smarttool.py",
   "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
         "data operations"
     ],
     "description": "Prepare training data for SmartTool",
-    "docker_image": "supervisely/data-operations:6.73.217",
+    "docker_image": "supervisely/data-operations:6.73.564",
     "instance_version": "6.11.19",
     "main_script": "src/create_trainset_for_smarttool.py",
     "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -11,7 +11,7 @@
     ],
     "description": "Prepare training data for SmartTool",
     "docker_image": "supervisely/data-operations:6.73.564",
-    "instance_version": "6.11.19",
+    "instance_version": "6.15.60",
     "main_script": "src/create_trainset_for_smarttool.py",
     "modal_template": "src/modal.html",
     "gui_template": "src/gui.html",

--- a/config.json
+++ b/config.json
@@ -1,29 +1,29 @@
 {
-    "name": "Create Trainset for SmartTool",
-    "type": "app",
-    "categories": [
-        "neural network",
-        "images",
-        "interactive segmentation",
-        "nn tools",
-        "augmentation",
-        "data operations"
+  "name": "Create Trainset for SmartTool",
+  "type": "app",
+  "categories": [
+    "neural network",
+    "images",
+    "interactive segmentation",
+    "nn tools",
+    "augmentation",
+    "data operations"
+  ],
+  "description": "Prepare training data for SmartTool",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "instance_version": "6.15.60",
+  "main_script": "src/create_trainset_for_smarttool.py",
+  "modal_template": "src/modal.html",
+  "gui_template": "src/gui.html",
+  "task_location": "workspace_tasks",
+  "isolate": true,
+  "icon": "https://img.icons8.com/fluent/96/000000/fantasy.png",
+  "icon_background": "#FFFFFF",
+  "context_menu": {
+    "target": [
+      "images_project"
     ],
-    "description": "Prepare training data for SmartTool",
-    "docker_image": "supervisely/data-operations:6.73.564",
-    "instance_version": "6.15.60",
-    "main_script": "src/create_trainset_for_smarttool.py",
-    "modal_template": "src/modal.html",
-    "gui_template": "src/gui.html",
-    "task_location": "workspace_tasks",
-    "isolate": true,
-    "icon": "https://img.icons8.com/fluent/96/000000/fantasy.png",
-    "icon_background": "#FFFFFF",
-    "context_menu": {
-        "target": [
-            "images_project"
-        ],
-        "context_category": "Training data"
-    },
-    "poster": "https://user-images.githubusercontent.com/106374579/182811208-a9090964-3213-4f06-9b4f-d4b9deeb86fa.png"
+    "context_category": "Training data"
+  },
+  "poster": "https://user-images.githubusercontent.com/106374579/182811208-a9090964-3213-4f06-9b4f-d4b9deeb86fa.png"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.55
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
